### PR TITLE
feat: add date filters to stock opname report

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -14,6 +14,11 @@ class CategoryController extends Controller
         return view('categories.index', compact('categories'));
     }
 
+    public function create()
+    {
+        return view('categories.create');
+    }
+
     public function store(Request $request)
     {
         $request->validate([
@@ -60,7 +65,4 @@ class CategoryController extends Controller
         return redirect()->route('categories.index')
                          ->with('success', 'Kategori berhasil dihapus.');
     }
-
-    // Metode create, show, edit biasanya bisa disatukan dalam modal di halaman index untuk UI yang lebih simpel.
-    // Namun jika ingin halaman terpisah, buat methodnya seperti di SupplierController.
 }

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -30,6 +30,8 @@ class ReportController extends Controller
         $rawDate = null;
         $displayDate = null;
         $products = collect();
+        $totalPurchase = 0;
+        $totalSell = 0;
 
         if ($hasFilter) {
             $rawDate = match ($filter) {
@@ -69,6 +71,9 @@ class ReportController extends Controller
 
                     return $product;
                 });
+
+            $totalPurchase = $products->sum(fn($p) => $p->stock_calc * $p->price_purchase);
+            $totalSell = $products->sum(fn($p) => $p->stock_calc * $p->price_sell);
         }
 
         return view('reports.stock_opname', [
@@ -77,6 +82,8 @@ class ReportController extends Controller
             'date' => $rawDate,
             'displayDate' => $displayDate,
             'hasFilter' => $hasFilter,
+            'totalPurchase' => $totalPurchase,
+            'totalSell' => $totalSell,
         ]);
     }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -21,47 +21,60 @@ class ReportController extends Controller
     {
         $filter = $request->input('filter', 'date');
 
-        $rawDate = match ($filter) {
-            'month' => $request->input('month', now()->format('Y-m')),
-            'year' => $request->input('year', now()->format('Y')),
-            default => $request->input('date', now()->toDateString()),
+        $hasFilter = match ($filter) {
+            'month' => $request->filled('month'),
+            'year' => $request->filled('year'),
+            default => $request->filled('date'),
         };
 
-        switch ($filter) {
-            case 'month':
-                $endDate = Carbon::createFromFormat('Y-m', $rawDate)->endOfMonth();
-                $displayDate = Carbon::createFromFormat('Y-m', $rawDate)->translatedFormat('F Y');
-                break;
-            case 'year':
-                $endDate = Carbon::createFromFormat('Y', $rawDate)->endOfYear();
-                $displayDate = $rawDate;
-                break;
-            default:
-                $endDate = Carbon::parse($rawDate)->endOfDay();
-                $displayDate = Carbon::parse($rawDate)->translatedFormat('d F Y');
-                break;
+        $rawDate = null;
+        $displayDate = null;
+        $products = collect();
+
+        if ($hasFilter) {
+            $rawDate = match ($filter) {
+                'month' => $request->input('month'),
+                'year' => $request->input('year'),
+                default => $request->input('date'),
+            };
+
+            switch ($filter) {
+                case 'month':
+                    $endDate = Carbon::createFromFormat('Y-m', $rawDate)->endOfMonth();
+                    $displayDate = Carbon::createFromFormat('Y-m', $rawDate)->translatedFormat('F Y');
+                    break;
+                case 'year':
+                    $endDate = Carbon::createFromFormat('Y', $rawDate)->endOfYear();
+                    $displayDate = $rawDate;
+                    break;
+                default:
+                    $endDate = Carbon::parse($rawDate)->endOfDay();
+                    $displayDate = Carbon::parse($rawDate)->translatedFormat('d F Y');
+                    break;
+            }
+
+            $products = Product::with('category')
+                ->withSum(['stockMovements as stock_in' => function ($query) use ($endDate) {
+                    $query->where('type', 'in')->where('created_at', '<=', $endDate);
+                }], 'quantity')
+                ->withSum(['stockMovements as stock_out' => function ($query) use ($endDate) {
+                    $query->where('type', 'out')->where('created_at', '<=', $endDate);
+                }], 'quantity')
+                ->orderBy('name')
+                ->get()
+                ->map(function ($product) {
+                    $product->stock_calc = ($product->stock_in - $product->stock_out);
+
+                    return $product;
+                });
         }
-
-        $products = Product::with('category')
-            ->withSum(['stockMovements as stock_in' => function ($query) use ($endDate) {
-                $query->where('type', 'in')->where('created_at', '<=', $endDate);
-            }], 'quantity')
-            ->withSum(['stockMovements as stock_out' => function ($query) use ($endDate) {
-                $query->where('type', 'out')->where('created_at', '<=', $endDate);
-            }], 'quantity')
-            ->orderBy('name')
-            ->get()
-            ->map(function ($product) {
-                $product->stock_calc = ($product->stock_in - $product->stock_out);
-
-                return $product;
-            });
 
         return view('reports.stock_opname', [
             'products' => $products,
             'filter' => $filter,
             'date' => $rawDate,
             'displayDate' => $displayDate,
+            'hasFilter' => $hasFilter,
         ]);
     }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Product;
 use App\Models\StockMovement;
 use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 class ReportController extends Controller
 {
@@ -16,10 +17,46 @@ class ReportController extends Controller
     {
         return view('reports.index');
     }
-    public function stockOpname()
+    public function stockOpname(Request $request)
     {
-        $products = Product::with('category')->orderBy('name')->get();
-        return view('reports.stock_opname', compact('products'));
+        $filter = $request->input('filter', 'date');
+        $rawDate = $request->input('date', now()->toDateString());
+
+        switch ($filter) {
+            case 'month':
+                $endDate = Carbon::createFromFormat('Y-m', $rawDate)->endOfMonth();
+                $displayDate = Carbon::createFromFormat('Y-m', $rawDate)->translatedFormat('F Y');
+                break;
+            case 'year':
+                $endDate = Carbon::createFromFormat('Y', $rawDate)->endOfYear();
+                $displayDate = $rawDate;
+                break;
+            default:
+                $endDate = Carbon::parse($rawDate)->endOfDay();
+                $displayDate = Carbon::parse($rawDate)->translatedFormat('d F Y');
+                break;
+        }
+
+        $products = Product::with('category')
+            ->withSum(['stockMovements as stock_in' => function ($query) use ($endDate) {
+                $query->where('type', 'in')->where('created_at', '<=', $endDate);
+            }], 'quantity')
+            ->withSum(['stockMovements as stock_out' => function ($query) use ($endDate) {
+                $query->where('type', 'out')->where('created_at', '<=', $endDate);
+            }], 'quantity')
+            ->orderBy('name')
+            ->get()
+            ->map(function ($product) {
+                $product->stock_calc = ($product->stock_in - $product->stock_out);
+                return $product;
+            });
+
+        return view('reports.stock_opname', [
+            'products' => $products,
+            'filter' => $filter,
+            'date' => $rawDate,
+            'displayDate' => $displayDate,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -53,17 +53,19 @@ class ReportController extends Controller
                     break;
             }
 
+            // Hitung stok sistem per produk hingga akhir periode yang dipilih
+            $stockByProduct = StockMovement::selectRaw(
+                    'product_id, SUM(CASE WHEN type = "in" THEN quantity ELSE -quantity END) as qty'
+                )
+                ->where('created_at', '<=', $endDate)
+                ->groupBy('product_id')
+                ->pluck('qty', 'product_id');
+
             $products = Product::with('category')
-                ->withSum(['stockMovements as stock_in' => function ($query) use ($endDate) {
-                    $query->where('type', 'in')->where('created_at', '<=', $endDate);
-                }], 'quantity')
-                ->withSum(['stockMovements as stock_out' => function ($query) use ($endDate) {
-                    $query->where('type', 'out')->where('created_at', '<=', $endDate);
-                }], 'quantity')
                 ->orderBy('name')
                 ->get()
-                ->map(function ($product) {
-                    $product->stock_calc = ($product->stock_in - $product->stock_out);
+                ->map(function ($product) use ($stockByProduct) {
+                    $product->stock_calc = (int) ($stockByProduct[$product->id] ?? 0);
 
                     return $product;
                 });

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Product;
 use App\Models\StockMovement;
-use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use Illuminate\Http\Request;
 
 class ReportController extends Controller
 {
@@ -17,10 +16,16 @@ class ReportController extends Controller
     {
         return view('reports.index');
     }
+
     public function stockOpname(Request $request)
     {
         $filter = $request->input('filter', 'date');
-        $rawDate = $request->input('date', now()->toDateString());
+
+        $rawDate = match ($filter) {
+            'month' => $request->input('month', now()->format('Y-m')),
+            'year' => $request->input('year', now()->format('Y')),
+            default => $request->input('date', now()->toDateString()),
+        };
 
         switch ($filter) {
             case 'month':
@@ -48,6 +53,7 @@ class ReportController extends Controller
             ->get()
             ->map(function ($product) {
                 $product->stock_calc = ($product->stock_in - $product->stock_out);
+
                 return $product;
             });
 
@@ -71,9 +77,9 @@ class ReportController extends Controller
         if ($request->filled('product_id')) {
             $selectedProduct = Product::find($request->product_id);
             $movements = StockMovement::where('product_id', $request->product_id)
-                                      ->with('user')
-                                      ->latest()
-                                      ->paginate(20);
+                ->with('user')
+                ->latest()
+                ->paginate(20);
         }
 
         return view('reports.product_history', compact('products', 'movements', 'selectedProduct'));

--- a/resources/views/categories/create.blade.php
+++ b/resources/views/categories/create.blade.php
@@ -1,0 +1,26 @@
+<x-app-layout>
+    <x-slot name="header"><h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Tambah Kategori Baru') }}</h2></x-slot>
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="POST" action="{{ route('categories.store') }}">
+                        @csrf
+                        <div>
+                            <x-input-label for="name" :value="__('Nama Kategori')" />
+                            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
+                            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                        </div>
+                        <div class="mt-4">
+                            <x-input-label for="description" :value="__('Deskripsi')" />
+                            <textarea name="description" id="description" rows="3" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm">{{ old('description') }}</textarea>
+                        </div>
+                        <div class="flex items-center justify-end mt-4">
+                            <x-primary-button>{{ __('Simpan') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -4,30 +4,17 @@
         <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
-                    {{-- Form Tambah Kategori --}}
-                    <h3 class="font-semibold mb-4">Tambah Kategori Baru</h3>
-                    <form action="{{ route('categories.store') }}" method="POST" class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-                        @csrf
-                        <div class="md:col-span-2">
-                            <x-input-label for="name" value="Nama Kategori"/>
-                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" required/>
-                             <x-input-error :messages="$errors->get('name')" class="mt-2" />
-                        </div>
-                        <div>
-                            <x-primary-button>Simpan</x-primary-button>
-                        </div>
-                    </form>
-
-                    <hr class="my-6">
-
-                    {{-- Tabel Daftar Kategori --}}
-                    <h3 class="font-semibold mb-4">Daftar Kategori</h3>
-                     @if (session('success'))
+                    @if (session('success'))
                         <div class="mb-4 p-4 bg-green-100 text-green-700 rounded-lg">{{ session('success') }}</div>
                     @endif
-                     @if (session('error'))
+                    @if (session('error'))
                         <div class="mb-4 p-4 bg-red-100 text-red-700 rounded-lg">{{ session('error') }}</div>
                     @endif
+
+                    <div class="flex justify-end mb-4">
+                        <a href="{{ route('categories.create') }}" class="px-4 py-2 bg-indigo-600 text-white rounded-md">Tambah Kategori</a>
+                    </div>
+
                     <div class="overflow-x-auto">
                         <table class="min-w-full bg-white">
                             <tbody>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -26,6 +26,10 @@
                     @endcan
 
                     @role('Admin')
+                        <x-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">
+                            <svg class="h-5 w-5 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M10.75 4a.75.75 0 00-1.5 0v9.19l-2.72-2.72a.75.75 0 10-1.06 1.06l4 4a.75.75 0 001.06 0l4-4a.75.75 0 10-1.06-1.06l-2.72 2.72V4z"/></svg>
+                            {{ __('Kategori') }}
+                        </x-nav-link>
                         <x-nav-link :href="route('products.index')" :active="request()->routeIs('products.*')">
                              <svg class="h-5 w-5 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path d="M3.25 4A2.25 2.25 0 001 6.25v7.5A2.25 2.25 0 003.25 16h13.5A2.25 2.25 0 0019 13.75v-7.5A2.25 2.25 0 0016.75 4H3.25zM16.5 6.75h-13v7h13v-7z" /></svg>
                             {{ __('Produk') }}

--- a/resources/views/reports/stock_opname.blade.php
+++ b/resources/views/reports/stock_opname.blade.php
@@ -30,11 +30,11 @@
                             </div>
                             <div id="input-month" class="{{ $filter != 'month' ? 'hidden' : '' }}">
                                 <x-input-label for="month" value="Pilih Bulan" />
-                                <input type="month" id="month" name="date" value="{{ $filter == 'month' ? $date : '' }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
+                                <input type="month" id="month" name="month" value="{{ $filter == 'month' ? $date : '' }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
                             </div>
                             <div id="input-year" class="{{ $filter != 'year' ? 'hidden' : '' }}">
                                 <x-input-label for="year" value="Pilih Tahun" />
-                                <input type="number" id="year" name="date" min="2000" max="2100" value="{{ $filter == 'year' ? $date : now()->format('Y') }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
+                                <input type="number" id="year" name="year" min="2000" max="2100" value="{{ $filter == 'year' ? $date : '' }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
                             </div>
                             <div>
                                 <x-primary-button>Filter</x-primary-button>
@@ -99,9 +99,19 @@
     <script>
         function toggleInputs() {
             const type = document.getElementById('filter').value;
+            const dateInput = document.getElementById('date');
+            const monthInput = document.getElementById('month');
+            const yearInput = document.getElementById('year');
+
             document.getElementById('input-date').classList.toggle('hidden', type !== 'date');
             document.getElementById('input-month').classList.toggle('hidden', type !== 'month');
             document.getElementById('input-year').classList.toggle('hidden', type !== 'year');
+
+            dateInput.disabled = type !== 'date';
+            monthInput.disabled = type !== 'month';
+            yearInput.disabled = type !== 'year';
         }
+
+        document.addEventListener('DOMContentLoaded', toggleInputs);
     </script>
 </x-app-layout>

--- a/resources/views/reports/stock_opname.blade.php
+++ b/resources/views/reports/stock_opname.blade.php
@@ -14,8 +14,36 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
+                    <form action="{{ route('reports.stock_opname') }}" method="GET" class="mb-6">
+                        <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+                            <div>
+                                <x-input-label for="filter" value="Filter" />
+                                <select name="filter" id="filter" onchange="toggleInputs()" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm">
+                                    <option value="date" {{ $filter == 'date' ? 'selected' : '' }}>Tanggal</option>
+                                    <option value="month" {{ $filter == 'month' ? 'selected' : '' }}>Bulan</option>
+                                    <option value="year" {{ $filter == 'year' ? 'selected' : '' }}>Tahun</option>
+                                </select>
+                            </div>
+                            <div id="input-date" class="{{ $filter != 'date' ? 'hidden' : '' }}">
+                                <x-input-label for="date" value="Pilih Tanggal" />
+                                <input type="date" id="date" name="date" value="{{ $filter == 'date' ? $date : '' }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
+                            </div>
+                            <div id="input-month" class="{{ $filter != 'month' ? 'hidden' : '' }}">
+                                <x-input-label for="month" value="Pilih Bulan" />
+                                <input type="month" id="month" name="date" value="{{ $filter == 'month' ? $date : '' }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
+                            </div>
+                            <div id="input-year" class="{{ $filter != 'year' ? 'hidden' : '' }}">
+                                <x-input-label for="year" value="Pilih Tahun" />
+                                <input type="number" id="year" name="date" min="2000" max="2100" value="{{ $filter == 'year' ? $date : now()->format('Y') }}" class="block mt-1 w-full border-gray-300 rounded-md shadow-sm" />
+                            </div>
+                            <div>
+                                <x-primary-button>Filter</x-primary-button>
+                            </div>
+                        </div>
+                    </form>
+
                     <div class="mb-4">
-                        <p><strong>Tanggal Laporan:</strong> {{ \Carbon\Carbon::now()->translatedFormat('d F Y') }}</p>
+                        <p><strong>Tanggal Laporan:</strong> {{ $displayDate }}</p>
                         <p class="text-sm text-gray-600">Gunakan daftar ini untuk membandingkan stok yang tercatat di sistem dengan stok fisik di gudang.</p>
                     </div>
 
@@ -39,12 +67,12 @@
                                         <td class="py-2 px-3 border-b text-sm">{{ $product->sku }}</td>
                                         <td class="py-2 px-3 border-b text-sm">{{ $product->name }}</td>
                                         <td class="py-2 px-3 border-b text-sm">{{ $product->category->name ?? 'N/A' }}</td>
-                                        <td class="py-2 px-3 border-b text-center text-sm font-bold">{{ $product->stock }}</td>
+                                        <td class="py-2 px-3 border-b text-center text-sm font-bold">{{ $product->stock_calc }}</td>
                                         <td class="py-2 px-3 border-b text-sm">
                                             {{-- Kolom kosong untuk diisi manual saat cek fisik --}}
                                         </td>
                                         <td class="py-2 px-3 border-b text-right text-sm">
-                                            Rp {{ number_format($product->stock * $product->price_purchase, 0, ',', '.') }}
+                                            Rp {{ number_format($product->stock_calc * $product->price_purchase, 0, ',', '.') }}
                                         </td>
                                     </tr>
                                 @empty
@@ -57,7 +85,7 @@
                                 <tr>
                                     <td colspan="6" class="py-2 px-3 text-right text-sm">Total Nilai Inventaris:</td>
                                     <td class="py-2 px-3 text-right text-sm">
-                                        Rp {{ number_format($products->sum(function($p) { return $p->stock * $p->price_purchase; }), 0, ',', '.') }}
+                                        Rp {{ number_format($products->sum(function($p) { return $p->stock_calc * $p->price_purchase; }), 0, ',', '.') }}
                                     </td>
                                 </tr>
                             </tfoot>
@@ -68,4 +96,12 @@
             </div>
         </div>
     </div>
+    <script>
+        function toggleInputs() {
+            const type = document.getElementById('filter').value;
+            document.getElementById('input-date').classList.toggle('hidden', type !== 'date');
+            document.getElementById('input-month').classList.toggle('hidden', type !== 'month');
+            document.getElementById('input-year').classList.toggle('hidden', type !== 'year');
+        }
+    </script>
 </x-app-layout>

--- a/resources/views/reports/stock_opname.blade.php
+++ b/resources/views/reports/stock_opname.blade.php
@@ -59,6 +59,7 @@
                                         <th class="py-2 px-3 border-b text-center text-sm">Stok Sistem</th>
                                         <th class="py-2 px-3 border-b text-center text-sm" style="width: 15%;">Stok Fisik</th>
                                         <th class="py-2 px-3 border-b text-right text-sm">Nilai Stok (Beli)</th>
+                                        <th class="py-2 px-3 border-b text-right text-sm">Nilai Stok (Jual)</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -73,12 +74,15 @@
                                                 {{-- Kolom kosong untuk diisi manual saat cek fisik --}}
                                             </td>
                                             <td class="py-2 px-3 border-b text-right text-sm">
-                                                Rp {{ number_format($product->stock_calc * $product->price_purchase, 0, ',', '.') }}
+                                                Rp {{ number_format($product->stock_calc * $product->price_purchase, 2, ',', '.') }}
+                                            </td>
+                                            <td class="py-2 px-3 border-b text-right text-sm">
+                                                Rp {{ number_format($product->stock_calc * $product->price_sell, 2, ',', '.') }}
                                             </td>
                                         </tr>
                                     @empty
                                         <tr>
-                                            <td colspan="7" class="py-4 px-3 text-center text-sm">Tidak ada data produk untuk ditampilkan.</td>
+                                            <td colspan="8" class="py-4 px-3 text-center text-sm">Tidak ada data produk untuk ditampilkan.</td>
                                         </tr>
                                     @endforelse
                                 </tbody>
@@ -86,7 +90,10 @@
                                     <tr>
                                         <td colspan="6" class="py-2 px-3 text-right text-sm">Total Nilai Inventaris:</td>
                                         <td class="py-2 px-3 text-right text-sm">
-                                            Rp {{ number_format($products->sum(function($p) { return $p->stock_calc * $p->price_purchase; }), 0, ',', '.') }}
+                                            Rp {{ number_format($totalPurchase, 2, ',', '.') }}
+                                        </td>
+                                        <td class="py-2 px-3 text-right text-sm">
+                                            Rp {{ number_format($totalSell, 2, ',', '.') }}
                                         </td>
                                     </tr>
                                 </tfoot>

--- a/resources/views/reports/stock_opname.blade.php
+++ b/resources/views/reports/stock_opname.blade.php
@@ -42,55 +42,59 @@
                         </div>
                     </form>
 
-                    <div class="mb-4">
-                        <p><strong>Tanggal Laporan:</strong> {{ $displayDate }}</p>
-                        <p class="text-sm text-gray-600">Gunakan daftar ini untuk membandingkan stok yang tercatat di sistem dengan stok fisik di gudang.</p>
-                    </div>
+                    @if ($hasFilter)
+                        <div class="mb-4">
+                            <p><strong>Tanggal Laporan:</strong> {{ $displayDate }}</p>
+                            <p class="text-sm text-gray-600">Gunakan daftar ini untuk membandingkan stok yang tercatat di sistem dengan stok fisik di gudang.</p>
+                        </div>
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full bg-white border">
-                            <thead class="bg-gray-200">
-                                <tr>
-                                    <th class="py-2 px-3 border-b text-left text-sm">No.</th>
-                                    <th class="py-2 px-3 border-b text-left text-sm">SKU</th>
-                                    <th class="py-2 px-3 border-b text-left text-sm">Nama Produk</th>
-                                    <th class="py-2 px-3 border-b text-left text-sm">Kategori</th>
-                                    <th class="py-2 px-3 border-b text-center text-sm">Stok Sistem</th>
-                                    <th class="py-2 px-3 border-b text-center text-sm" style="width: 15%;">Stok Fisik</th>
-                                    <th class="py-2 px-3 border-b text-right text-sm">Nilai Stok (Beli)</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @forelse ($products as $product)
-                                    <tr class="hover:bg-gray-50">
-                                        <td class="py-2 px-3 border-b text-sm">{{ $loop->iteration }}</td>
-                                        <td class="py-2 px-3 border-b text-sm">{{ $product->sku }}</td>
-                                        <td class="py-2 px-3 border-b text-sm">{{ $product->name }}</td>
-                                        <td class="py-2 px-3 border-b text-sm">{{ $product->category->name ?? 'N/A' }}</td>
-                                        <td class="py-2 px-3 border-b text-center text-sm font-bold">{{ $product->stock_calc }}</td>
-                                        <td class="py-2 px-3 border-b text-sm">
-                                            {{-- Kolom kosong untuk diisi manual saat cek fisik --}}
-                                        </td>
-                                        <td class="py-2 px-3 border-b text-right text-sm">
-                                            Rp {{ number_format($product->stock_calc * $product->price_purchase, 0, ',', '.') }}
-                                        </td>
-                                    </tr>
-                                @empty
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full bg-white border">
+                                <thead class="bg-gray-200">
                                     <tr>
-                                        <td colspan="7" class="py-4 px-3 text-center text-sm">Tidak ada data produk untuk ditampilkan.</td>
+                                        <th class="py-2 px-3 border-b text-left text-sm">No.</th>
+                                        <th class="py-2 px-3 border-b text-left text-sm">SKU</th>
+                                        <th class="py-2 px-3 border-b text-left text-sm">Nama Produk</th>
+                                        <th class="py-2 px-3 border-b text-left text-sm">Kategori</th>
+                                        <th class="py-2 px-3 border-b text-center text-sm">Stok Sistem</th>
+                                        <th class="py-2 px-3 border-b text-center text-sm" style="width: 15%;">Stok Fisik</th>
+                                        <th class="py-2 px-3 border-b text-right text-sm">Nilai Stok (Beli)</th>
                                     </tr>
-                                @endforelse
-                            </tbody>
-                            <tfoot class="font-bold bg-gray-100">
-                                <tr>
-                                    <td colspan="6" class="py-2 px-3 text-right text-sm">Total Nilai Inventaris:</td>
-                                    <td class="py-2 px-3 text-right text-sm">
-                                        Rp {{ number_format($products->sum(function($p) { return $p->stock_calc * $p->price_purchase; }), 0, ',', '.') }}
-                                    </td>
-                                </tr>
-                            </tfoot>
-                        </table>
-                    </div>
+                                </thead>
+                                <tbody>
+                                    @forelse ($products as $product)
+                                        <tr class="hover:bg-gray-50">
+                                            <td class="py-2 px-3 border-b text-sm">{{ $loop->iteration }}</td>
+                                            <td class="py-2 px-3 border-b text-sm">{{ $product->sku }}</td>
+                                            <td class="py-2 px-3 border-b text-sm">{{ $product->name }}</td>
+                                            <td class="py-2 px-3 border-b text-sm">{{ $product->category->name ?? 'N/A' }}</td>
+                                            <td class="py-2 px-3 border-b text-center text-sm font-bold">{{ $product->stock_calc }}</td>
+                                            <td class="py-2 px-3 border-b text-sm">
+                                                {{-- Kolom kosong untuk diisi manual saat cek fisik --}}
+                                            </td>
+                                            <td class="py-2 px-3 border-b text-right text-sm">
+                                                Rp {{ number_format($product->stock_calc * $product->price_purchase, 0, ',', '.') }}
+                                            </td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="7" class="py-4 px-3 text-center text-sm">Tidak ada data produk untuk ditampilkan.</td>
+                                        </tr>
+                                    @endforelse
+                                </tbody>
+                                <tfoot class="font-bold bg-gray-100">
+                                    <tr>
+                                        <td colspan="6" class="py-2 px-3 text-right text-sm">Total Nilai Inventaris:</td>
+                                        <td class="py-2 px-3 text-right text-sm">
+                                            Rp {{ number_format($products->sum(function($p) { return $p->stock_calc * $p->price_purchase; }), 0, ',', '.') }}
+                                        </td>
+                                    </tr>
+                                </tfoot>
+                            </table>
+                        </div>
+                    @else
+                        <p class="text-center text-gray-600">Silakan pilih tanggal, bulan, atau tahun untuk menampilkan laporan stok.</p>
+                    @endif
 
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- allow choosing stock opname report by date, month or year
- compute stock quantities as of selected period using stock movements

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b823df738083319a04024265c687ee